### PR TITLE
Extend CI to automate publishing to VSCE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
         files: "*.vsix"
       env:
         GITHUB_TOKEN: ${{ secrets.PAT }}
+    - name: Publish
+      run: num run deploy
+      env:
+        VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
   changelog:
     needs: release

--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
 		"test": "node ./out/test/runTest.js",
 		"changelog": "auto-changelog",
 		"changelog-debug": "auto-changelog --template json --output changelog-data.json",
-		"package": "vsce package"
+		"package": "vsce package",
+		"deploy": "vsce publish"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.2.18",


### PR DESCRIPTION
This PR extends the GitHub action to also publish the extension to the Visual Studio Code extensions marketplace.